### PR TITLE
Implement OpenMP

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,5 +53,8 @@
         "stdexcept": "cpp",
         "streambuf": "cpp",
         "typeinfo": "cpp"
-    }
+    },
+    "cSpell.words": [
+        "stoi"
+    ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,25 @@
 #.DEFAULT_GOAL := generate #choose the default goal instead of it being the first one
 .PHONY: clean #tells make that these goals are not files but some other thing
 
-# compiler options, debug and performance
-cppDebug = g++ \
-           -std=c++17 \
-		   -Wall \
-		   -Wextra \
-		   -Wpedantic \
-		   -g \
-		   -O0
-cppPerf = g++ -std=c++17 -O3
-cppCompiler = ${cppDebug} #the version used
+# Compiler path
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	compPath = /usr/local/bin/g++-11
+else
+	compPath := $(shell which g++)
+endif
+
+# Compiler options, debug and performance
+cppDebugFlags = -std=c++17 \
+				-Wall \
+				-Wextra \
+				-Wpedantic \
+				-g \
+				-O0
+cppPerfFlags = -std=c++17 -O3
+OMP_FLAG = -fopenmp
+# cppFlags = ${cppDebugFlags} #the version used
+cppFlags = ${cppPerfFlags} #the version used
 
 
 # Make a list of all the source files that end in .cpp
@@ -23,12 +32,12 @@ OBJS = $(SRCS:.c=.o)
 # to do is indented
 # $@ is an automatic variable that is the target name
 rw-main.exe : $(OBJS)
-	$(cppCompiler) $(OBJS) -o  bin/$@
+	$(compPath) $(cppFlags) $(OMP_FLAG) $(OBJS) -o  bin/$@
 	@echo "Build Complete"
 
 # Create all object files.
 %.o: %.cpp
-	$(cppCompiler) -c $< -o $@
+	$(compPath) $(cppFlags) $(OMP_FLAG) -c $< -o $@
 
 clean:
 	@echo "Cleaning up..."

--- a/README.md
+++ b/README.md
@@ -3,10 +3,23 @@ A project for the RPI summer school to implement a random walk routine for study
 
 
 ## Dependencies:
-* bash >= 5.x for example
+* C++ 17
+* GCC 11. Earlier compilers will likely work, this is the only one that has been tested
 
 
 ## Summary
 
 
 ## Setup Instructions
+- Edit the makefile to choose if you want to compile with OpenMP and whether to
+  use the debug or performance compile flags
+  - To disable OpenMP comment out this line: `OMP_FLAG = -fopenmp`
+  - To choose which compiler preset to use comment out whichever `cppFlags = `
+    line that you don't want
+- `make`
+- The executable will be deposited in `<repo-root>/bin/rw_main.exe`
+- Run the executable with the required arguments.
+  - arguments:
+    1. Path to the save file
+    2. (optional) Number of OpenMP threads to use. Defaults to the max number of
+       possible threads

--- a/src/rw-main.cpp
+++ b/src/rw-main.cpp
@@ -11,8 +11,8 @@
 #include <iostream>
 #include <string>
 #include <chrono>
-#include <vector>
 #include <random>
+#include <omp.h>
 
 #include "utility.h"
 
@@ -20,14 +20,36 @@ using std::cout;
 using std::cin;
 using std::endl;
 
-int main()
+/*!
+ * \brief Main function for the random walk program. Controls execution of the
+ * various components and provides user output.
+ *
+ * \param argc Total number of command line arguments
+ * \param argv Array of arguments.
+ * \return int 0 if successful
+ */
+int main(int argc, char const *argv[])
 {
     // Start timer
     auto start = std::chrono::high_resolution_clock::now();
 
     // Setting for program
-    int const numWalkers = 1E3;  /// The total number of walkers to make
-    int const numSteps   = 1E3;  /// The number of steps that each walker should take
+    int const numWalkers = 1E6;  /// The total number of walkers to make
+    int const numSteps   = 1E4;  /// The number of steps that each walker should take
+    std::string savePath;        /// The path to save the output to
+    int ompNumThreads;           /// Number of OMP threads to use
+
+    // Gather inputs
+    if (argc == 2) savePath = argv[1];  /// The path to save the file to
+    if (argc == 3)
+    {
+        ompNumThreads = std::stoi(argv[2]);
+    }
+    else
+    {
+        ompNumThreads = omp_get_max_threads();
+    }
+    cout << "Running with " << ompNumThreads << " OpenMP threads" << endl;
 
     // Initialize/Seed the random number generator
     std::random_device rd;
@@ -38,43 +60,47 @@ int main()
     stdVector1D xPosFinal(numWalkers, 0.),
                 yPosFinal(numWalkers, 0.);
 
-    // Main loop. Loop through each walker
-    for (size_t i = 0; i < numWalkers; i++)
+    // Setup parallel region
+    #pragma omp parallel num_threads(ompNumThreads)
     {
-        double xTemp=0., yTemp=0.;
-
-        // Loop through each step for each walker
-        for (size_t j = 0; j < numSteps; j++)
+        #pragma omp for
+        // Main loop. Loop through each walker
+        for (size_t i = 0; i < numWalkers; i++)
         {
-            // generate a random double
-            double randNum = distr(eng);
+            double xTemp=0., yTemp=0.;
 
-            // Choose which value to update
-            if (randNum < 0.25)
+            // Loop through each step for each walker
+            for (size_t j = 0; j < numSteps; j++)
             {
-                xTemp += 1.;
+                // generate a random double
+                double randNum = distr(eng);
+
+                // Choose which value to update
+                if (randNum < 0.25)
+                {
+                    xTemp += 1.;
+                }
+                else if (randNum < 0.5)
+                {
+                    xTemp -= 1.;
+                }
+                else if (randNum < 0.75)
+                {
+                    yTemp += 1.;
+                }
+                else
+                {
+                    yTemp -= 1.;
+                }
             }
-            else if (randNum < 0.5)
-            {
-                xTemp -= 1.;
-            }
-            else if (randNum < 0.75)
-            {
-                yTemp += 1.;
-            }
-            else
-            {
-                yTemp -= 1.;
-            }
+        // Save the last position of the walker
+        xPosFinal[i] = xTemp;
+        yPosFinal[i] = yTemp;
         }
-
-    // Save the last position of the walker
-    xPosFinal[i] = xTemp;
-    yPosFinal[i] = yTemp;
     }
 
     // Save the vectors to a csv file
-    utils::saveState(xPosFinal, yPosFinal);
+    utils::saveState(xPosFinal, yPosFinal, savePath);
 
     // Stop timer and print execution time. Time options are nanoseconds,
     // microseconds, milliseconds, seconds, minutes, hours. To pick one just

--- a/src/utility.h
+++ b/src/utility.h
@@ -36,7 +36,8 @@ namespace utils
  * \param yPos The vector of y-positions
  */
 void saveState(stdVector1D const &xPos,
-               stdVector1D const &yPos)
+               stdVector1D const &yPos,
+               std::string savePath)
 {
     // Make sure the vectors are the same size
     if (xPos.size() != yPos.size())
@@ -49,8 +50,8 @@ void saveState(stdVector1D const &xPos,
 
     // Open the savefile
     std::ofstream saveFile;
-    saveFile.open("../output/walkerFinalPositions.csv");
-
+    saveFile.open(savePath.append("/walkerFinalPositions.csv"));
+    
     // Check that the save file opened
     if (saveFile.is_open())
     {
@@ -67,7 +68,8 @@ void saveState(stdVector1D const &xPos,
     }
     else
     {
-        throw std::runtime_error("Savefile failed to open. Exiting.");
+        perror("Savefile failed to open");
+        throw std::runtime_error("Exiting.");
     }
 
     // Close the save file


### PR DESCRIPTION
Implemented a simple OpenMP parallel for loop over the main loop.
There are now two launch arguments. The first one is the path to the
directory to store the save file and the second (optional) argument
indicate the number of OpenMP threads to use. If not specified it
defaults to the maximum number allowed by OpenMP

- Updated the makefile for OpenMP and setting the compiler path
  semi-automatically
- Updated the readme with new launch instructions
- Changed how the savefile took paths to work with OpenMP