### PR TITLE
Implement OpenMP

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,6 +52,10 @@
         "sstream": "cpp",
         "stdexcept": "cpp",
         "streambuf": "cpp",
-        "typeinfo": "cpp"
-    }
+        "typeinfo": "cpp",
+        "iomanip": "cpp"
+    },
+    "cSpell.words": [
+        "stoi"
+    ]
 }

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,25 @@
 #.DEFAULT_GOAL := generate #choose the default goal instead of it being the first one
 .PHONY: clean #tells make that these goals are not files but some other thing
 
-# compiler options, debug and performance
-cppDebug = g++ \
-           -std=c++17 \
-		   -Wall \
-		   -Wextra \
-		   -Wpedantic \
-		   -g \
-		   -O0
-cppPerf = g++ -std=c++17 -O3
-cppCompiler = ${cppDebug} #the version used
+# Compiler path
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	compPath = /usr/local/bin/g++-11
+else
+	compPath := $(shell which g++)
+endif
+
+# Compiler options, debug and performance
+cppDebugFlags = -std=c++17 \
+				-Wall \
+				-Wextra \
+				-Wpedantic \
+				-g \
+				-O0
+cppPerfFlags = -std=c++17 -O3
+OMP_FLAG = -fopenmp
+# cppFlags = ${cppDebugFlags} #the version used
+cppFlags = ${cppPerfFlags} #the version used
 
 
 # Make a list of all the source files that end in .cpp
@@ -23,12 +32,12 @@ OBJS = $(SRCS:.c=.o)
 # to do is indented
 # $@ is an automatic variable that is the target name
 rw-main.exe : $(OBJS)
-	$(cppCompiler) $(OBJS) -o  bin/$@
+	$(compPath) $(cppFlags) $(OMP_FLAG) $(OBJS) -o  bin/$@
 	@echo "Build Complete"
 
 # Create all object files.
 %.o: %.cpp
-	$(cppCompiler) -c $< -o $@
+	$(compPath) $(cppFlags) $(OMP_FLAG) -c $< -o $@
 
 clean:
 	@echo "Cleaning up..."

--- a/README.md
+++ b/README.md
@@ -3,10 +3,23 @@ A project for the RPI summer school to implement a random walk routine for study
 
 
 ## Dependencies:
-* bash >= 5.x for example
+* C++ 17
+* GCC 11. Earlier compilers will likely work, this is the only one that has been tested
 
 
 ## Summary
 
 
 ## Setup Instructions
+- Edit the makefile to choose if you want to compile with OpenMP and whether to
+  use the debug or performance compile flags
+  - To disable OpenMP comment out this line: `OMP_FLAG = -fopenmp`
+  - To choose which compiler preset to use comment out whichever `cppFlags = `
+    line that you don't want
+- `make`
+- The executable will be deposited in `<repo-root>/bin/rw_main.exe`
+- Run the executable with the required arguments.
+  - arguments:
+    1. Path to the save file
+    2. (optional) Number of OpenMP threads to use. Defaults to the max number of
+       possible threads

--- a/src/PerfTimer.h
+++ b/src/PerfTimer.h
@@ -1,0 +1,212 @@
+/*!
+ * \file PerfTimer.h
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Contains a timing class for simple performance timing and statistics
+ * of code
+ * \version 1.0
+ * \date 2020-09-24
+ *
+ * \copyright Copyright (c) 2020
+ *
+ */
+#ifndef __PERFTIMER__H__
+#define __PERFTIMER__H__
+
+#include <chrono>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <numeric>
+#include <algorithm>
+
+/*!
+ * \brief A class for timing pieces of code
+ * \details To use this timer class simply initialize it with the name you want
+ * to assign that timer, call PerfTimer::startTimer() when you want to start the
+ * timer and PerfTimer::stopTimer() to end the timer. You can call start/stop
+ * pairs as often as you want, each time difference will be saved and used for
+ * final statistics. Statistics are accessed by calling PerfTimer::reportStats()
+ * which writes the stats to std::cout or by calling PerfTimer::saveTimingData()
+ * which saves the statistics and raw time differences to a given csv file. Note
+ * that it will overwrite without asking
+ *
+ */
+class PerfTimer
+{
+private:
+    /// Stores the start time
+    std::chrono::high_resolution_clock::time_point _startTime;
+
+    /// Stores time differences in nanoseconds
+    std::vector<double> _timeDiff;
+
+    /// Indicates if a timer is active. If there is an active timer then it's
+    /// `false`, else it is `true`
+    bool _activeTimer;
+
+    /// The name of the timer. To be printed out in the final output
+    std::string _name;
+
+    /*!
+     * \brief Figure out the proper units for a given time.
+     * \details Determines the proper units to use for time (nanoseconds,
+     * microseconds, milliseconds, seconds, minutes, or hours) and returns the
+     * time scaled to that unit along with the unit itself
+     *
+     * \param[in,out] time
+     * \param[out] unit
+     */
+    void _converter(double &time, std::string &unit)
+    {
+        if (time <= 1.0E3)  // less than a microsecond
+        {
+            // Return time in nanoseconds
+            unit = "ns";
+        }
+        else if (time <= 1.0E6)  // less than a millisecond
+        {
+            // Return time in microseconds
+            time *= 1.E-3;
+            unit = "\u00B5s";
+        }
+        else if (time <= 1.0E9)  // less than a second
+        {
+            // Return time in milliseconds
+            time *= 1.E-6;
+            unit = "ms";
+        }
+        else if (time <= 6.0E11)   // less than 10 minutes
+        {
+            // Return time in seconds
+            time *= 1.E-9;
+            unit = "s";
+        }
+        else if (time <= 1.08E13)  // less than 3 hours
+        {
+            // Return time in minutes
+            time *= (1.E-9) / 60. ;
+            unit = "mins";
+        }
+        else   // greater than 3 hours
+        {
+            // Return time in hours
+            time *= (1.E-9) / 3600. ;
+            unit = "hrs";
+        }
+
+    };
+
+public:
+    /*!
+     * \brief Start the timer
+     * \details First checks if a timer is active. If the timer is active then
+     * nothing is done and an error message is printed. Else it starts the timer
+     */
+    void startTimer()
+    {
+        // Check if a timer is already running
+        if (_activeTimer)
+        {
+            std::cout << _name << "::timer is already active. No action taken";
+        }
+        else
+        {
+            _startTime = std::chrono::high_resolution_clock::now();
+        }
+    };
+
+    /*!
+     * \brief Stop the timer
+     * \details Stops the timer, appends the change in time to a private
+     * std::vector in nanoseconds, then sets _activeTimer to false
+     */
+    void stopTimer()
+    {
+        // Compute the time difference and write it to _timeDiff
+        double diff = static_cast<double> ((std::chrono::high_resolution_clock::now() - _startTime).count());
+        _timeDiff.push_back(diff);
+
+        _activeTimer = false;
+    };
+
+    /*!
+     * \brief Compute and print out all the statistics for the timer
+     *
+     * \param[in] outStream What stream to write out to. Defaults to std::cout
+     */
+    void reportStats(std::ostream &outStream = std::cout)
+    {
+        // Compute statistics in nanoseconds
+        double totalTime = std::accumulate(_timeDiff.begin(), _timeDiff.end(), 0.);
+        double avgTime   = totalTime / static_cast<double>(_timeDiff.size());
+        auto   minMax    = std::minmax_element(_timeDiff.begin(),_timeDiff.end());
+        double minTime   = *minMax.first ;
+        double maxTime   = *minMax.second;
+
+        // Convert values
+        std::string totalTimeUnit, avgTimeUnit, minTimeUnit, maxTimeUnit;
+        _converter(totalTime, totalTimeUnit);
+        _converter(avgTime,   avgTimeUnit);
+        _converter(minTime,   minTimeUnit);
+        _converter(maxTime,   maxTimeUnit);
+
+        outStream << "Timer name: " << _name << std::endl  << "  " <<
+        "Number of trials: " << _timeDiff.size()           << ", " <<
+        "Total time: "       << totalTime << totalTimeUnit << ", " <<
+        "Average Time: "     << avgTime   << avgTimeUnit   << ", " <<
+        "Fastest Run: "      << minTime   << minTimeUnit   << ", " <<
+        "Slowest Run: "      << maxTime   << maxTimeUnit   << std::endl;
+    };
+
+    /*!
+     * \brief Writes all the time differences (in nanoseconds) to the given file
+     * along with timer name and timer statistics.
+     *
+     * \details File format is .csv with two header lines. The two headers lines
+     * are what is written out by PerfTimer::reportStats and the third line is
+     * the measure time differences for each use of the timer.
+     *
+     * \param[in] filePath The path at which to write the output file. If the
+     * file already exists it will be overwritten without asking.
+     */
+    void saveTimingData(std::string filePath)
+    {
+        // Open the file
+        std::ofstream saveFile(filePath);
+
+        // Write out the header info to the file
+        reportStats(saveFile);
+
+        // Write the vector to the file
+        saveFile << _timeDiff[0];
+        if (_timeDiff.size() > 0)
+        {
+            for (size_t i = 1; i < _timeDiff.size(); i++)
+            {
+                saveFile << "," << _timeDiff[i];
+            }
+        }
+        saveFile << std::endl;
+
+        // Close the file
+        saveFile.close();
+    };
+
+    /*!
+     * \brief Construct a new Perf Timer object
+     *
+     * \param[in] name The name of the timer
+     */
+    PerfTimer(std::string name);
+    ~PerfTimer() = default;
+};
+
+PerfTimer::PerfTimer(std::string name)
+    :
+    _activeTimer(false),
+    _name(name)
+{
+}
+#endif  //!__PERFTIMER__H__

--- a/src/rw-main.cpp
+++ b/src/rw-main.cpp
@@ -11,23 +11,52 @@
 #include <iostream>
 #include <string>
 #include <chrono>
-#include <vector>
 #include <random>
+#include <omp.h>
 
 #include "utility.h"
+#include "PerfTimer.h"
 
 using std::cout;
 using std::cin;
 using std::endl;
 
-int main()
+/*!
+ * \brief Main function for the random walk program. Controls execution of the
+ * various components and provides user output.
+ *
+ * \param argc Total number of command line arguments
+ * \param argv Array of arguments.
+ * \return int 0 if successful
+ */
+int main(int argc, char const *argv[])
 {
-    // Start timer
-    auto start = std::chrono::high_resolution_clock::now();
+    // =========================================================================
+    // Settings and Setup
+    // =========================================================================
+    // Declare timers and start overall timer
+    PerfTimer overallTimer("Overall Timer");
+    PerfTimer walkerTimer("Random Walker Timer");
+    PerfTimer saveTimer("Saving Timer");
+    overallTimer.startTimer();
 
     // Setting for program
-    int const numWalkers = 1E3;  /// The total number of walkers to make
-    int const numSteps   = 1E3;  /// The number of steps that each walker should take
+    int const numWalkers = 1E6;  /// The total number of walkers to make
+    int const numSteps   = 1E4;  /// The number of steps that each walker should take
+    std::string savePath;        /// The path to save the output to
+    int ompNumThreads;           /// Number of OMP threads to use
+
+    // Gather inputs
+    if (argc >= 2) savePath = argv[1];  /// The path to save the file to
+    if (argc == 3)
+    {
+        ompNumThreads = std::stoi(argv[2]);
+    }
+    else
+    {
+        ompNumThreads = omp_get_max_threads();
+    }
+    cout << "Running with " << ompNumThreads << " OpenMP threads" << endl;
 
     // Initialize/Seed the random number generator
     std::random_device rd;
@@ -38,51 +67,73 @@ int main()
     stdVector1D xPosFinal(numWalkers, 0.),
                 yPosFinal(numWalkers, 0.);
 
-    // Main loop. Loop through each walker
-    for (size_t i = 0; i < numWalkers; i++)
+    // =========================================================================
+    // End Settings and setup
+    // =========================================================================
+
+    // =========================================================================
+    // Random walk
+    // =========================================================================
+    walkerTimer.startTimer();
+    // Setup parallel region
+    #pragma omp parallel num_threads(ompNumThreads)
     {
-        double xTemp=0., yTemp=0.;
-
-        // Loop through each step for each walker
-        for (size_t j = 0; j < numSteps; j++)
+        #pragma omp for
+        // Main loop. Loop through each walker
+        for (size_t i = 0; i < numWalkers; i++)
         {
-            // generate a random double
-            double randNum = distr(eng);
+            double xTemp=0., yTemp=0.;
 
-            // Choose which value to update
-            if (randNum < 0.25)
+            // Loop through each step for each walker
+            for (size_t j = 0; j < numSteps; j++)
             {
-                xTemp += 1.;
+                // generate a random double
+                double randNum = distr(eng);
+
+                // Choose which value to update
+                if (randNum < 0.25)
+                {
+                    xTemp += 1.;
+                }
+                else if (randNum < 0.5)
+                {
+                    xTemp -= 1.;
+                }
+                else if (randNum < 0.75)
+                {
+                    yTemp += 1.;
+                }
+                else
+                {
+                    yTemp -= 1.;
+                }
             }
-            else if (randNum < 0.5)
-            {
-                xTemp -= 1.;
-            }
-            else if (randNum < 0.75)
-            {
-                yTemp += 1.;
-            }
-            else
-            {
-                yTemp -= 1.;
-            }
+        // Save the last position of the walker
+        xPosFinal[i] = xTemp;
+        yPosFinal[i] = yTemp;
         }
-
-    // Save the last position of the walker
-    xPosFinal[i] = xTemp;
-    yPosFinal[i] = yTemp;
     }
+    walkerTimer.stopTimer();
+    // =========================================================================
+    // End random walk
+    // =========================================================================
 
+    // =========================================================================
+    // Saving and cleanup
+    // =========================================================================
     // Save the vectors to a csv file
-    utils::saveState(xPosFinal, yPosFinal);
+    saveTimer.startTimer();
+    utils::saveState(xPosFinal, yPosFinal, savePath);
+    saveTimer.stopTimer();
 
-    // Stop timer and print execution time. Time options are nanoseconds,
-    // microseconds, milliseconds, seconds, minutes, hours. To pick one just
-    // change `using FpTime` and the cout statement suitably.
-    auto stop = std::chrono::high_resolution_clock::now();
-    using FpTime = std::chrono::duration<float, std::chrono::seconds::period>;
-    static_assert(std::chrono::treat_as_floating_point<FpTime::rep>::value,"Rep required to be floating point");
-    auto duration = FpTime(stop - start);
-    cout << "Time to execute: " << duration.count() << " seconds";
+    // Overall timer stop and return timing information
+    overallTimer.stopTimer();
+    overallTimer.reportStats();
+    walkerTimer.reportStats();
+    saveTimer.reportStats();
+    // =========================================================================
+    // End saving and cleanup
+    // =========================================================================
+
     return 0;
 }

--- a/src/utility.h
+++ b/src/utility.h
@@ -36,7 +36,8 @@ namespace utils
  * \param yPos The vector of y-positions
  */
 void saveState(stdVector1D const &xPos,
-               stdVector1D const &yPos)
+               stdVector1D const &yPos,
+               std::string savePath)
 {
     // Make sure the vectors are the same size
     if (xPos.size() != yPos.size())
@@ -49,7 +50,8 @@ void saveState(stdVector1D const &xPos,
 
     // Open the savefile
     std::ofstream saveFile;
-    saveFile.open("../output/walkerFinalPositions.csv");
+    std::string fullName =  savePath.append("/walkerFinalPositions.csv");
+    saveFile.open(fullName);
 
     // Check that the save file opened
     if (saveFile.is_open())
@@ -67,7 +69,8 @@ void saveState(stdVector1D const &xPos,
     }
     else
     {
-        throw std::runtime_error("Savefile failed to open. Exiting.");
+        perror("Savefile failed to open");
+        throw std::runtime_error("Exiting.");
     }
 
     // Close the save file


### PR DESCRIPTION
Implemented a simple OpenMP parallel for loop over the main loop.
There are now two launch arguments. The first one is the path to the
directory to store the save file and the second (optional) argument
indicate the number of OpenMP threads to use. If not specified it
defaults to the maximum number allowed by OpenMP

- Updated the makefile for OpenMP and setting the compiler path
  semi-automatically
- Updated the readme with new launch instructions
- Changed how the savefile took paths to work with OpenMP
- Add a more sophisticated class for timing